### PR TITLE
Add source code link to gemspec file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.1 (2020-03-24)
+
+* Added source code link to `scimitar.gemspec` metadata for RubyGems.
+
 # 1.0.0 (2020-03-24)
 
 * Initial public release.

--- a/lib/scimitar/version.rb
+++ b/lib/scimitar/version.rb
@@ -3,7 +3,7 @@ module Scimitar
   # Gem version. If this changes, be sure to re-run "bundle install" or
   # "bundle update".
   #
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 
   # Date for VERSION. If this changes, be sure to re-run "bundle install"
   # or "bundle update".

--- a/scimitar.gemspec
+++ b/scimitar.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.files       = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.rdoc']
   s.test_files  = Dir.glob('spec/**/*.rb')
   s.homepage    = 'https://ripglobal.com/'
+  s.metadata    = { "source_code_uri" => "https://github.com/RIPGlobal/scimitar" }
 
   s.required_ruby_version = '>= 2.7.2'
 


### PR DESCRIPTION
RubyGems won't let me repush 1.0.0 and yanking is a bad look, so I'd rather have the mistake out in the open and just do a patch version update.

Without this, you've got RDoc links & RIP Global's home page, but no GitHub link visible within RubyGems.